### PR TITLE
Added a fix for certain types of AMP urls

### DIFF
--- a/models/link.py
+++ b/models/link.py
@@ -34,6 +34,7 @@ class CanonicalType(enum.Enum):
     REL = "rel"
     CANURL = "canurl"
     OG_URL = "og_url"
+    META_REDIRECT = 'meta_redirect'
     GOOGLE_MANUAL_REDIRECT = "google_manual_redirect"
     GOOGLE_JS_REDIRECT = "google_js_redirect"
     BING_ORIGINAL_URL = "bing_original_url"


### PR DESCRIPTION
An example of a link that would not have been handled before, and that is handled now: https://amp-reddit-com.cdn.ampproject.org/wp/s/amp.reddit.com/r/CombatFootage/comments/o765q4/russian_coast_guard_video_of_hms_defender/?usqp=mq331AQKKAFQArABIIACAw%3D%3D